### PR TITLE
Survey_Common_Action.php: handle failed mkdir target

### DIFF
--- a/application/core/Survey_Common_Action.php
+++ b/application/core/Survey_Common_Action.php
@@ -1201,7 +1201,14 @@ class Survey_Common_Action extends CAction
         }
 
         if (!is_dir($destdir)) {
-                    mkdir($destdir);
+                    if (!mkdir($destdir, 0777, true)) {
+                        return array( array(), array(
+                           "filename" => '',
+                           "status" => gT("Unable to create directory `%s`.",$destdir)
+                        ) );
+                    };
+        }
+
         }
 
         $dh = opendir($extractdir);


### PR DESCRIPTION
Handle case if target dir does not exist for whatever reason and cannot be created. This might be a permissions problem, no more inodes, etc.

Fixed issue # : none created
Dev: 
Dev: 